### PR TITLE
removes an additional conditional that allows for discarded (i.e. ipv…

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -64,8 +64,7 @@ func PullIPAddress(targetType string) (string, error) {
 			ip = ip.To4()
 			if ip == nil {
 				continue // not an ipv4 address
-			}
-			if strings.HasPrefix(ip.String(), "10.") == true {
+			} else if strings.HasPrefix(ip.String(), "10.") == true {
 				if targetType == "private" {
 					return ip.String(), nil
 				} else {


### PR DESCRIPTION
…6) addresses to end up in the return body--ip.To4 returns false and continues, but is re-evaluated and returned in the following block, which is now a separate set of conditions for the same test which does use this evaluation